### PR TITLE
Courses view working

### DIFF
--- a/src/components/Courses/CourseCard.js
+++ b/src/components/Courses/CourseCard.js
@@ -58,7 +58,6 @@ export default function CourseCard(props) {
         }
         className="course-card"
       >
-        <h3>Program: {course.program.programname}</h3>
         <h4>Course Code: {course.coursecode}</h4>
         <p>Description: {course.coursedescription}</p>
         <Button onClick={viewCourseHandler} type="primary">


### PR DESCRIPTION
# What's here (& why)

- One line of data that isn't being passed anymore (program.programname in the course object) with the new shape had to be removed. This was the issue on why the courses weren't rendering. New bug on view course within programs.

# Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete / work-in-progress, PR is for discussion or feedback
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



