### PR TITLE
close modal course fix

### DIFF
--- a/src/components/RestCourses/EditCourseForm.js
+++ b/src/components/RestCourses/EditCourseForm.js
@@ -112,7 +112,10 @@ function EditCourseForm(props) {
         <Modal
           visible={props.visible}
           onCancel={props.hideModal}
-          onOk={submitForm}
+          onOk={() => {
+            submitForm();
+            props.hideModal();
+          }}
         >
           {innerForm}
         </Modal>


### PR DESCRIPTION
# What's here (& why)

When closing a modal after editing a course, you normally need to manually click "cancel." to exit out of it.
https://trello.com/c/3IwBHLia/97-closing-module-after-editing-course-need-to-manually-click-cancel

# Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete / work-in-progress, PR is for discussion or feedback
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How has this been tested?

- [x] Tested locally
- [ ] Test suite provides the same results as prior to making changes

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
